### PR TITLE
Fix nil TTLs from crashing route53

### DIFF
--- a/lib/route53.rb
+++ b/lib/route53.rb
@@ -175,7 +175,7 @@ module Route53
           ident_records = record.search("SetIdentifier")
           dom_records.push(DNSRecord.new(record.search("Name").first.innerText,
                         record.search("Type").first.innerText,
-                        (record.search("TTL").first.innerText if zone_apex_records.empty?),
+                        ((record.search("TTL").first.nil? ? '' : record.search("TTL").first.innerText) if zone_apex_records.empty?),
                         values,
                         self,
                         (zone_apex_records.first.innerText unless zone_apex_records.empty?),


### PR DESCRIPTION
``` bash
$ route53 -z zumba.com. -l |grep zumbathon
/Users/alfredmoreno/.rvm/gems/ruby-1.9.2-p290/gems/route53-0.2.1/lib/route53.rb:178:in `block in get_records': undefined method `innerText' for nil:NilClass (NoMethodError)
    from /Users/alfredmoreno/.rvm/gems/ruby-1.9.2-p290/gems/route53-0.2.1/lib/route53.rb:164:in `each'
    from /Users/alfredmoreno/.rvm/gems/ruby-1.9.2-p290/gems/route53-0.2.1/lib/route53.rb:164:in `get_records'
    from /Users/alfredmoreno/.rvm/gems/ruby-1.9.2-p290/gems/route53-0.2.1/lib/route53/cli.rb:149:in `block in list'
    from /Users/alfredmoreno/.rvm/gems/ruby-1.9.2-p290/gems/route53-0.2.1/lib/route53/cli.rb:146:in `each'
    from /Users/alfredmoreno/.rvm/gems/ruby-1.9.2-p290/gems/route53-0.2.1/lib/route53/cli.rb:146:in `list'
    from /Users/alfredmoreno/.rvm/gems/ruby-1.9.2-p290/gems/route53-0.2.1/lib/route53/cli.rb:139:in `process_arguments'
    from /Users/alfredmoreno/.rvm/gems/ruby-1.9.2-p290/gems/route53-0.2.1/lib/route53/cli.rb:32:in `run'
    from /Users/alfredmoreno/.rvm/gems/ruby-1.9.2-p290/gems/route53-0.2.1/bin/route53:11:in `<top (required)>'
    from /Users/alfredmoreno/.rvm/gems/ruby-1.9.2-p290/bin/route53:19:in `load'
    from /Users/alfredmoreno/.rvm/gems/ruby-1.9.2-p290/bin/route53:19:in `<main>'
```

Today I started getting crashes using the route53 gem.  The crashes were due to the TTL field coming in NIL on one of our records.  I've posted a fix that prevents this from being an issue and would like you to please merge it.

Thanks!
