### PR TITLE
Update API version to 2012-12-12

### DIFF
--- a/lib/route53.rb
+++ b/lib/route53.rb
@@ -19,7 +19,7 @@ module Route53
     attr_reader :endpoint
     attr_reader :verbose
 
-    def initialize(accesskey,secret,api='2011-05-05',endpoint='https://route53.amazonaws.com/',verbose=false,ssl_no_verify=false)
+    def initialize(accesskey,secret,api='2012-12-12',endpoint='https://route53.amazonaws.com/',verbose=false,ssl_no_verify=false)
       @accesskey = accesskey
       @secret = secret
       @api = api


### PR DESCRIPTION
If you have any A ALIAS record types with weighting in your hosted zone, the API version this gem is using will spit out an error about not being able to return the record because it contains an attribute not supported by the API endpoint.

The fix is to simply update the API version to 2012-12-12, which is what this pull request does.

Could you also cut a new gem if you choose to merge this?
