### PR TITLE
add health_id for record that have health check associated

### DIFF
--- a/lib/route53/dns_record.rb
+++ b/lib/route53/dns_record.rb
@@ -7,8 +7,9 @@ module Route53
     attr_reader :weight
     attr_reader :ident
     attr_reader :zone_apex
+    attr_reader :health_id
 
-    def initialize(name,type,ttl,values,zone,zone_apex=nil,weight=nil,ident=nil, evaluate_target_health=false)
+    def initialize(name,type,ttl,values,zone,zone_apex=nil,weight=nil,ident=nil, evaluate_target_health=false, health_id=nil)
       @name = name
       unless @name.end_with?(".")
         @name += "."
@@ -21,6 +22,7 @@ module Route53
       @weight = weight
       @ident = ident
       @evaluate_target_health = evaluate_target_health
+      @health_id = health_id
     end
 
     def gen_change_xml(xml,action)
@@ -32,6 +34,7 @@ module Route53
           record.SetIdentifier(@ident) if @ident
           record.Weight(@weight) if @weight
           record.TTL(@ttl) unless @zone_apex
+          record.HealthCheckId(@health_id) if @health_id
           if @zone_apex
             record.AliasTarget { |targets|
               targets.HostedZoneId(@zone_apex)


### PR DESCRIPTION
Hi,
I was creating automatically some records and I saw this feature missing.
After reading on http://docs.aws.amazon.com/Route53/latest/APIReference/API_ListHostedZones.html how it worked, I made this fork/diff.

-- Patrick