### PR TITLE
Remove specific nokogiri version dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'nokogiri', '~> 1.5.10' if RUBY_VERSION.start_with? '1.8'

--- a/route53.gemspec
+++ b/route53.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.5"
 
   s.add_dependency "ruby-hmac"
-  s.add_dependency "nokogiri", '~> 1.5.10'
+  s.add_dependency "nokogiri"
   s.add_dependency "builder"
 
   s.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Allow a variety of nokogiri versions to suit different environments,
packages etc.  Only pin the version of nokogiri for Ruby 1.8 in the
Gemfile so tests pass.

1.8.7 users can install or pin an appropriate version from their own
Gemfiles.