### PR TITLE
Handle subdomains in get_zones

### DIFF
--- a/lib/route53/connection.rb
+++ b/lib/route53/connection.rb
@@ -65,7 +65,7 @@ module Route53
         (0 ... name_arr.size).each do |i|
           search_domain = name_arr.last(name_arr.size-i).join('.')+"."
           zone_select = zones.select { |z| z.name == search_domain }
-          return zone_select
+          return zone_select if zone_select.any?
         end
         return nil
       end

--- a/spec/lib/route53/connection_spec.rb
+++ b/spec/lib/route53/connection_spec.rb
@@ -18,6 +18,20 @@ describe Route53::Connection do
       end
     end
 
+    it "handles a single domain name" do
+      VCR.use_cassette("aws_zones", :record => :none) do
+        conn = Route53::Connection.new(credentials('access_key'), credentials('secret_key'))
+        expect(conn.get_zones('50projects.com.').map(&:name)).to eq(['50projects.com.'])
+      end
+    end
+
+    it "handles subdomains" do
+      VCR.use_cassette("aws_zones", :record => :none) do
+        conn = Route53::Connection.new(credentials('access_key'), credentials('secret_key'))
+        expect(conn.get_zones('sub.50projects.com.').map(&:name)).to eq(['50projects.com.'])
+      end
+    end
+
     it "handles truncated responses"
     it "handles subqueries based on the hostedzone"
   end


### PR DESCRIPTION
The code to search for the longest matching domain was already there,
but it returned on the very first selection even if that didn't contain
any matches. By making the return conditional the intended behaviour is
achieved.

Fixes GH-42